### PR TITLE
set max word limit to 50

### DIFF
--- a/all_views_completions.py
+++ b/all_views_completions.py
@@ -8,7 +8,7 @@ import time
 
 # limits to prevent bogging down the system
 MIN_WORD_SIZE = 3
-MAX_WORD_SIZE = 30
+MAX_WORD_SIZE = 50
 
 MAX_VIEWS = 20
 MAX_WORDS_PER_VIEW = 100


### PR DESCRIPTION
In ruby rails application, it's easy to overcome the 30 characters limitation, so I'd like to raise it to 50
