### PR TITLE
Add syntax exclusions. Also adds preference menu and settings file.

### DIFF
--- a/All Autocomplete.sublime-settings
+++ b/All Autocomplete.sublime-settings
@@ -1,0 +1,7 @@
+{
+	// An array of syntaxes to exclude from checking. Can be partial string, like "css"
+	// "exclude_scopes_from_complete_triggers": [
+	// 	"css",
+	// 	"scss"
+	// ]
+}

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,35 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children": [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children": [
+                    {
+                        "caption": "All Autocomplete",
+                        "children": [
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/SublimeAllAutocomplete/All Autocomplete.sublime-settings"
+                                },
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/All Autocomplete.sublime-settings"
+                                },
+                                "caption": "Settings – User"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/all_views_completions.py
+++ b/all_views_completions.py
@@ -7,6 +7,9 @@ import re
 import time
 from os.path import basename
 
+settings = sublime.load_settings('All Autocomplete.sublime-settings')
+exclude_scopes = settings.get("exclude_scopes_from_complete_triggers", [])
+
 # limits to prevent bogging down the system
 MIN_WORD_SIZE = 3
 MAX_WORD_SIZE = 50
@@ -19,6 +22,12 @@ MAX_FIX_TIME_SECS_PER_VIEW = 0.01
 class AllAutocomplete(sublime_plugin.EventListener):
 
     def on_query_completions(self, view, prefix, locations):
+
+        # bypass if in ignored syntax list
+        for exclude_scope in exclude_scopes:
+            if view.scope_name(locations[0]).find(exclude_scope) != -1:
+                return
+
         words = []
 
         # Limit number of views but always include the active view. This


### PR DESCRIPTION
If syntax for current cursor location is in the excluded list, this plugin's autocompletion will be skipped and thus normal autocompletion rules will apply.

Addresses issues #12 #28 #45 