### PR TITLE
Can disable sourcing syntaxes for auto-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,15 @@ Settings
 
 You can disable the additional autocompletion provided by this package for specific source files and even select syntax within files. In the Sublime menu go to Preferences > Package Settings > All Autocomplete > Settings – User.
 
-Example: the following Setting would disable All Autocomplete for CSS and JavaScript code:
+Example: the following Setting would disable completions when you're editing CSS or JavaScript code, and would not source any completions from Markdown files:
 
 ```
 "exclude_from_completion": [
 	"css",
 	"js"
+],
+"exclude_sources": [
+  "markdown"
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ You can disable the additional autocompletion provided by this package for speci
 
 Example: the following Setting would disable completions when you're editing CSS or JavaScript code, and would not source any completions from Markdown files:
 
-```
+```json
 "exclude_from_completion": [
 	"css",
 	"js"
 ],
 "exclude_sources": [
   "markdown"
-]
+],
+"min_word_size": 5, // don't show completions for words with fewer than this many chars
+"max_word_size": 40 // don't show completions for words with more than this many chars
 ```
 
 The names provided in this list are matched against the so-called "syntax scope" of the currently autocompleted input. For example, in a CSS file, when you start typing a new CSS class name, the syntax scope is "source.css meta.selector.css". The names you provide in the config above are partially matched against this scope. This means, you can completely disable All Autocomplete for all CSS code by specifying "css" – or you can disable it only for specific parts, for example, CSS selectors by specifying "selector.css". Or to disable completion in comments, include "comment" in the list.

--- a/all_views_completions.py
+++ b/all_views_completions.py
@@ -7,9 +7,6 @@ import re
 import time
 from os.path import basename
 
-# limits to prevent bogging down the system
-MIN_WORD_SIZE = 3
-MAX_WORD_SIZE = 50
 
 MAX_VIEWS = 20
 MAX_WORDS_PER_VIEW = 100
@@ -70,6 +67,8 @@ def is_excluded(scope, excluded_scopes):
 
 
 def filter_words(words):
+    MIN_WORD_SIZE = settings.get("min_word_size", 3)
+    MAX_WORD_SIZE = settings.get("max_word_size", 50)
     return [w for w in words if MIN_WORD_SIZE <= len(w) <= MAX_WORD_SIZE][0:MAX_WORDS_PER_VIEW]
 
 

--- a/all_views_completions.py
+++ b/all_views_completions.py
@@ -20,12 +20,13 @@ def plugin_loaded():
     global settings
     settings = sublime.load_settings('All Autocomplete.sublime-settings')
 
+
 class AllAutocomplete(sublime_plugin.EventListener):
 
     def on_query_completions(self, view, prefix, locations):
         if is_disabled_in(view.scope_name(locations[0])):
             return []
-         
+
         words = []
 
         # Limit number of views but always include the active view. This
@@ -51,6 +52,8 @@ class AllAutocomplete(sublime_plugin.EventListener):
             contents = w.replace('$', '\\$')
             if v.id != view.id and v.file_name():
                 trigger += '\t(%s)' % basename(v.file_name())
+            if v.id == view.id:
+                trigger += '\tabc'
             matches.append((trigger, contents))
         return matches
 

--- a/all_views_completions.py
+++ b/all_views_completions.py
@@ -62,19 +62,18 @@ def is_disabled_in(scope):
             return True
     return False
 
+
 def filter_words(words):
-    words = words[0:MAX_WORDS_PER_VIEW]
-    return [w for w in words if MIN_WORD_SIZE <= len(w) <= MAX_WORD_SIZE]
+    return [w for w in words if MIN_WORD_SIZE <= len(w) <= MAX_WORD_SIZE][0:MAX_WORDS_PER_VIEW]
 
 
-# keeps first instance of every word and retains the original order
-# (n^2 but should not be a problem as len(words) <= MAX_VIEWS*MAX_WORDS_PER_VIEW)
+# keeps first instance of every word and retains the original order, O(n)
 def without_duplicates(words):
     result = []
-    used_words = []
+    used_words = set()
     for w, v in words:
         if w not in used_words:
-            used_words.append(w)
+            used_words.add(w)
             result.append((w, v))
     return result
 


### PR DESCRIPTION
Adds and documents the `exclude_sources` setting to make this possible.

Also:

- `MIN_WORD_SIZE`, `MAX_WORD_SIZE` configurable via settings, same default values as before
- `without_duplicated` perf improvement, O(n) instead of O(n^2)
- adds `"abc"` description for completions from current file

@alienhard 
Please let me know if there's anything I can do to clean up the PR, or whether its purpose is unclear. Thanks, and thanks for writing this plugin!